### PR TITLE
fix(openai): accept axum-style 'data:' SSE + skip role-announcement chunk for TTFT

### DIFF
--- a/src/apis/openai_api.rs
+++ b/src/apis/openai_api.rs
@@ -121,20 +121,35 @@ impl LLMApi for OaiApi {
                         // axum's Sse Event omits the space; vLLM includes it.
                         // Accept both — strip the colon, then trim leading whitespace.
                         let data_str = rest.trim_start();
-
                         if data_str == "[DONE]" {
                             break;
                         }
                         if data_str.contains(r#""delta""#) {
+                            // Parse the delta object once: needed both for role-only
+                            // detection and for content text accumulation.
+                            let delta = serde_json::from_str::<serde_json::Value>(data_str)
+                                .ok()
+                                .and_then(|v| v.pointer("/choices/0/delta").cloned());
+
+                            // OAI chat-completion streams open with a role-announcement
+                            // chunk (typically `{"role":"assistant","content":""}`) that
+                            // carries no generated content. Counting it would inflate
+                            // token_count and pull first_token_time down to the
+                            // time-to-role-chunk (network + queue admission) rather than
+                            // time-to-first-decoded-token. Skip when `role` is present
+                            // and `content` is missing / null / empty.
+                            if let Some(d) = delta.as_ref() {
+                                let content = d.get("content").and_then(|c| c.as_str()).unwrap_or("");
+                                let has_role = d.get("role").is_some();
+                                if has_role && content.is_empty() {
+                                    line.clear();
+                                    continue;
+                                }
+                            }
+
                             // Extract delta.content for output text accumulation
-                            if let Ok(v) = serde_json::from_str::<serde_json::Value>(data_str) {
-                                if let Some(content) = v
-                                    .get("choices")
-                                    .and_then(|c| c.get(0))
-                                    .and_then(|c| c.get("delta"))
-                                    .and_then(|d| d.get("content"))
-                                    .and_then(|c| c.as_str())
-                                {
+                            if let Some(d) = delta.as_ref() {
+                                if let Some(content) = d.get("content").and_then(|c| c.as_str()) {
                                     output_text.push_str(content);
                                 }
                             }

--- a/src/apis/openai_api.rs
+++ b/src/apis/openai_api.rs
@@ -116,8 +116,11 @@ impl LLMApi for OaiApi {
                         continue;
                     }
 
-                    if trimmed.starts_with("data: ") {
-                        let data_str = &trimmed[6..];
+                    if let Some(rest) = trimmed.strip_prefix("data:") {
+                        // SSE spec allows both "data: ..." and "data:..." (no space).
+                        // axum's Sse Event omits the space; vLLM includes it.
+                        // Accept both — strip the colon, then trim leading whitespace.
+                        let data_str = rest.trim_start();
 
                         if data_str == "[DONE]" {
                             break;


### PR DESCRIPTION
Fixes #26.

Two independent bugs in `src/apis/openai_api.rs` that together silently destroy TTFT/TPOT metrics whenever request-sim talks OAI streaming through any axum-based SSE proxy (e.g. blitz-router). Two commits, kept separate so they can be cherry-picked / reverted independently.

## Commit 1 — `fix(openai): accept SSE 'data:' chunks without leading space`

Parser used `starts_with(\"data: \")` (with literal space). axum's `Sse` + `Event::default().json_data(...)` emits `data:{...}` (no space) — both forms are valid per the SSE spec. Switch to `strip_prefix(\"data:\") + trim_start()` so both are accepted. vLLM-direct traffic (which uses the spaced form) is unaffected.

## Commit 2 — `fix(openai): skip role-announcement chunk when measuring TTFT`

OAI streams open with a role chunk that has no generated content (`{\"delta\":{\"role\":\"assistant\",\"content\":\"\"}}`). It is yielded before any decoding happens (in blitz-router as soon as `infer.generate_stream` returns from queue admission). Counting it pulled `first_token_time` down to network/queue latency (~4 ms on Qwen3-30B-A3B) instead of real prefill latency (~100-500 ms). Detect role-only chunks (`role` field present and `content` missing/null/empty) and skip them.

## Verification

Setup: master-a800, Qwen3-30B-A3B-Instruct on 1× A800, vLLM (yaullm @ `9e1d6c4ea`) ← blitz-router (`a310e3a`) ← request-sim (this PR), via metro CLI, trace-replay on bailian traceA.

| Stage | Successful (200) records | with `first_token_time` | ttft_p50 | tpot_p50 |
|---|---|---|---|---|
| Pre-fix | 11624 | **0 (0%)** | n/a | n/a |
| Post commit 1 only | 965 | 965 (100%) | 3.9 ms (role-chunk artifact) | 47 ms |
| Post commits 1+2 | 82 | 82 (100%) | **136 ms (real prefill)** | 48 ms |

Direct request-sim → vLLM (no router) was unaffected by either bug; both fixes are no-ops on the spaced form and only kick in when role/empty-content is present.

## Test plan

- [x] Built clean (`cargo build --release`, no new warnings)
- [x] Smoke against blitz-router 1-replica setup — TTFT/TPOT populated for all 200s
- [x] Smoke against vLLM-direct — still works (regression guard)
- [ ] Reviewer: please run against any other OAI-stream backend you have wired (SGLang? TGI? open-platform?) to confirm the role-only filter doesn't false-positive on chunks that legitimately set `role` together with non-empty `content`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)